### PR TITLE
Fix deprecation warning in specs:  WARN Selenium [DEPRECATION] [:browser_options]

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,7 +66,7 @@ RSpec.configure do |config|
     Capybara::Selenium::Driver.new(
       app,
       browser: :chrome,
-      options: args
+      capabilities: args
     )
   end
 


### PR DESCRIPTION
 :options as a parameter for driver initialization is deprecated.